### PR TITLE
tweak setup: add config text editor

### DIFF
--- a/setup.md
+++ b/setup.md
@@ -6,15 +6,23 @@ permalink: /setup/
 
 If you haven't done so already, to follow this lesson you will need to:
 
-1. Setup a GitHub account here: [https://github.com/](https://github.com/)
-2. Download and install git for your operating system: [https://git-scm.com/downloads](https://git-scm.com/downloads)
-3. Configure git by opening a terminal window and entering the following commands:
+1. Create a free [GitHub account](https://github.com/join) and confirm your email.
+2. Download and install Git for your operating system: [https://git-scm.com/downloads](https://git-scm.com/downloads) (*Note:* Git for Windows comes bundled with the Git BASH terminal that allows you use UNIX style commands on Windows)
+3. Configure Git by opening a terminal window and entering the following commands:
 
 ~~~
 $ git config --global user.name "Your Name"
 $ git config --global user.email "your@email"
-$ git config --global color.ui "auto"
 ~~~
 {: .bash}
 
-Note that the email address should be the same one you used when setting up your GitHub account.
+This user name and email will be recorded with each commit in the history of your repositories. 
+The email address should be the same one you used when setting up your GitHub account.
+
+By default, Git will use VI text editor. 
+Most people will want to change the default editor to something more familiar using the `core.editor` config (common options include Windows "notepad", Mac "edit -w", Linux "nano -w", or [others](https://help.github.com/articles/associating-text-editors-with-git/)): 
+
+~~~
+$ git config --global core.editor "notepad"
+~~~
+{: .bash}

--- a/setup.md
+++ b/setup.md
@@ -7,7 +7,7 @@ permalink: /setup/
 If you haven't done so already, to follow this lesson you will need to:
 
 1. Create a free [GitHub account](https://github.com/join) and confirm your email.
-2. Download and install Git for your operating system: [https://git-scm.com/downloads](https://git-scm.com/downloads) (*Note:* Git for Windows comes bundled with the Git BASH terminal that allows you use UNIX style commands on Windows)
+2. Download and install Git for your operating system: [https://git-scm.com/downloads](https://git-scm.com/downloads) (*Note:* Git for Windows comes bundled with the Git BASH terminal that allows you to use UNIX-style commands on Windows)
 3. Configure Git by opening a terminal window and entering the following commands:
 
 ~~~
@@ -19,8 +19,8 @@ $ git config --global user.email "your@email"
 This user name and email will be recorded with each commit in the history of your repositories. 
 The email address should be the same one you used when setting up your GitHub account.
 
-By default, Git will use VI text editor. 
-Most people will want to change the default editor to something more familiar using the `core.editor` config (common options include Windows "notepad", Mac "edit -w", Linux "nano -w", or [others](https://help.github.com/articles/associating-text-editors-with-git/)): 
+By default, Git will use the VI text editor. 
+Most people will want to change the default editor to something more familiar using the `core.editor` config (common options include Windows "notepad" or "Notepad ++", Mac "edit -w", Linux "nano -w", or [others](https://help.github.com/articles/associating-text-editors-with-git/)): 
 
 ~~~
 $ git config --global core.editor "notepad"


### PR DESCRIPTION
A few tweaks to the setup page.

I removed `git config --global color.ui "auto"` because this is the default already and seems unnecessary. 

I added setting a default text editor, because this can be a huge confusion later on went users merge something. The default default is Vi / Vim which [few understand](https://stackoverflow.blog/2017/05/23/stack-overflow-helping-one-million-developers-exit-vim/).