### PR TITLE
clarify git editor setup

### DIFF
--- a/setup.md
+++ b/setup.md
@@ -19,8 +19,11 @@ $ git config --global user.email "your@email"
 This user name and email will be recorded with each commit in the history of your repositories. 
 The email address should be the same one you used when setting up your GitHub account.
 
-By default, Git will use the VI text editor. 
-Most people will want to change the default editor to something more familiar using the `core.editor` config (common options include Windows "notepad" or "Notepad ++", Mac "edit -w", Linux "nano -w", or [others](https://help.github.com/articles/associating-text-editors-with-git/)): 
+By default, Git will open the Vi / Vim text editor to request commit messages (for example when merging conflicts).
+To avoid confusion, most people will want to change the default editor to something more familiar using the `core.editor` config. 
+Any text editor can be made default by adding the correct file path and command line options (see [GitHub help](https://help.github.com/articles/associating-text-editors-with-git/)). 
+However, the simplest `core.editor` values are `"notepad"` on Windows,  `"edit -w"` on Mac, and `"nano -w"` on Linux. 
+For example:
 
 ~~~
 $ git config --global core.editor "notepad"


### PR DESCRIPTION
further clarification of `core.editor` configuration.

re: #40 